### PR TITLE
Verify queue length when adding multiple operations

### DIFF
--- a/Tests/QueuerTests/QueuerTests.swift
+++ b/Tests/QueuerTests/QueuerTests.swift
@@ -140,7 +140,10 @@ internal class QueuerTests: XCTestCase {
             check += 1
         }
         queue.addOperation(concurrentOperation1)
+        XCTAssertEqual(queue.operationCount, 1)
+
         queue.addOperation(concurrentOperation2)
+        XCTAssertEqual(queue.operationCount, 2)
         
         DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(2)) {
             testExpectation.fulfill()


### PR DESCRIPTION
This PR adds extra assertions to verify the queue length when testing adding multiple operations to the same queue.

On Linux, there seem to be a bug (#19) that does not allow the queue to become longer than one, making everything serial.