### PR TITLE
Updating `success` property in `finish(success:)` method

### DIFF
--- a/Sources/Queuer/ConcurrentOperation.swift
+++ b/Sources/Queuer/ConcurrentOperation.swift
@@ -163,6 +163,8 @@ open class ConcurrentOperation: Operation {
             currentAttempt += 1
             shouldRetry = true
         }
+
+        self.success = success
     }
     
     /// Pause the current `Operation`, if it's supported.


### PR DESCRIPTION
As stated in #21, I've updated `success` property in `finish(success:)` method.