### PR TITLE
Add CIHelper to run test on Linux but not on CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,13 @@
 - `1.1.x` Releases - [1.1.0](#110---quality-of-service)
 - `1.0.x` Releases - [1.0.0](#100---first-queue)
 
-## [3.0.1](https://github.com/FabrizioBrancati/Queuer/releases/tag/3.0.0) - No Loop No Party
+## Develop
+
+### Added
+
+- Added CIHelper to run test on Linux but not on CI - [#33](https://github.com/FabrizioBrancati/Queuer/pull/33)
+
+## [3.0.1](https://github.com/FabrizioBrancati/Queuer/releases/tag/3.0.1) - No Loop No Party
 
 ### 4 May 2024
 

--- a/Tests/QueuerTests/ConcurrentOperationTests.swift
+++ b/Tests/QueuerTests/ConcurrentOperationTests.swift
@@ -109,7 +109,7 @@ final class ConcurrentOperationTests: XCTestCase {
     }
 
     func testAsyncChainedRetry() async {
-        if CIHelper.isRunningOnCI() {
+        if CIHelper.isNotRunningOnCI() {
             let queue = Queuer(name: "ConcurrentOperationTestChainedRetry")
             let testExpectation = expectation(description: "Chained Retry")
             let order = OrderHelper()

--- a/Tests/QueuerTests/ConcurrentOperationTests.swift
+++ b/Tests/QueuerTests/ConcurrentOperationTests.swift
@@ -27,14 +27,6 @@
 import Queuer
 import XCTest
 
-actor Order {
-    var order: [Int] = []
-
-    func append(_ element: Int) {
-        order.append(element)
-    }
-}
-
 final class ConcurrentOperationTests: XCTestCase {
     func testInitWithExecutionBlock() {
         let queue = Queuer(name: "ConcurrentOperationTestInitWithExecutionBlock")

--- a/Tests/QueuerTests/Helpers/CIHelper.swift
+++ b/Tests/QueuerTests/Helpers/CIHelper.swift
@@ -33,4 +33,11 @@ struct CIHelper {
     static func isRunningOnCI() -> Bool {
         ProcessInfo.processInfo.environment["GITHUB_RUN_ID"] != nil
     }
+
+    /// This method is needed because some tests cannot successfully run on CI,
+    /// but they do on a Linux Docker image.
+    /// - Returns: Returns `true` if not running on CI, otherwise `false`.
+    static func isNotRunningOnCI() -> Bool {
+        !isRunningOnCI()
+    }
 }

--- a/Tests/QueuerTests/Helpers/CIHelper.swift
+++ b/Tests/QueuerTests/Helpers/CIHelper.swift
@@ -1,0 +1,36 @@
+//
+//  CIHelper.swift
+//  Queuer
+//
+//  MIT License
+//
+//  Copyright (c) 2017 - 2024 Fabrizio Brancati
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+
+import Foundation
+
+struct CIHelper {
+    /// This method is needed because some tests cannot successfully run on CI,
+    /// but they do on a Linux Docker image.
+    /// - Returns: Returns `true` if running on CI, otherwise `false`.
+    static func isRunningOnCI() -> Bool {
+        ProcessInfo.processInfo.environment["GITHUB_RUN_ID"] != nil
+    }
+}

--- a/Tests/QueuerTests/Helpers/OrderHelper.swift
+++ b/Tests/QueuerTests/Helpers/OrderHelper.swift
@@ -1,0 +1,35 @@
+//
+//  OrderHelper.swift
+//  Queuer
+//
+//  MIT License
+//
+//  Copyright (c) 2017 - 2024 Fabrizio Brancati
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+
+import Foundation
+
+actor OrderHelper {
+    var order: [Int] = []
+
+    func append(_ element: Int) {
+        order.append(element)
+    }
+}

--- a/Tests/QueuerTests/QueuerTests.swift
+++ b/Tests/QueuerTests/QueuerTests.swift
@@ -30,7 +30,7 @@ import XCTest
 
 final class QueuerTests: XCTestCase {
     func testOperationCount() {
-        if CIHelper.isRunningOnCI() {
+        if CIHelper.isNotRunningOnCI() {
             let queue = Queuer(name: "QueuerTestOperationCount")
             let testExpectation = expectation(description: "Operation Count")
 
@@ -51,7 +51,7 @@ final class QueuerTests: XCTestCase {
     }
 
     func testOperations() {
-        if CIHelper.isRunningOnCI() {
+        if CIHelper.isNotRunningOnCI() {
             let queue = Queuer(name: "QueuerTestOperations")
             let testExpectation = expectation(description: "Operations")
 
@@ -78,7 +78,7 @@ final class QueuerTests: XCTestCase {
     }
 
     func testMaxConcurrentOperationCountSetToOne() {
-        if CIHelper.isRunningOnCI() {
+        if CIHelper.isNotRunningOnCI() {
             let testExpectation = expectation(description: "Max Concurrent Operation Count Set To One")
             var testString = ""
 
@@ -354,7 +354,7 @@ final class QueuerTests: XCTestCase {
     }
 
     func testWaitUnitlAllOperationsAreFinished() {
-        if CIHelper.isRunningOnCI() {
+        if CIHelper.isNotRunningOnCI() {
             let queue = Queuer(name: "QueuerTestWaitUnitlAllOperationsAreFinished")
             let testExpectation = expectation(description: "Wait Unitl All Operations Are Finished")
             var order: [Int] = []

--- a/Tests/QueuerTests/SchedulerTests.swift
+++ b/Tests/QueuerTests/SchedulerTests.swift
@@ -29,64 +29,68 @@ import Queuer
 import XCTest
 
 final class SchedulerTests: XCTestCase {
-    #if !os(Linux)
     func testInitWithoutHandler() {
-        let testExpectation = expectation(description: "Init Without Handler")
-        var order: [Int] = []
+        if CIHelper.isRunningOnCI() {
+            let testExpectation = expectation(description: "Init Without Handler")
+            var order: [Int] = []
 
-        var schedule = Scheduler(deadline: .now(), repeating: .seconds(1))
-        schedule.setHandler {
-            order.append(0)
-        }
+            var schedule = Scheduler(deadline: .now(), repeating: .seconds(1))
+            schedule.setHandler {
+                order.append(0)
+            }
 
-        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(3500)) {
-            testExpectation.fulfill()
-        }
+            DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(3500)) {
+                testExpectation.fulfill()
+            }
 
-        waitForExpectations(timeout: 5) { error in
-            XCTAssertNil(error)
-            XCTAssertEqual(order, [0, 0, 0, 0])
-            schedule.timer.cancel()
+            waitForExpectations(timeout: 5) { error in
+                XCTAssertNil(error)
+                XCTAssertEqual(order, [0, 0, 0, 0])
+                schedule.timer.cancel()
+            }
         }
     }
 
     func testInitWithHandler() {
-        let testExpectation = expectation(description: "Init With Handler")
-        var order: [Int] = []
-
-        let schedule = Scheduler(deadline: .now(), repeating: .never) {
-            order.append(0)
-        }
-
-        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(3500)) {
-            testExpectation.fulfill()
-        }
-
-        waitForExpectations(timeout: 5) { error in
-            XCTAssertNil(error)
-            XCTAssertEqual(order, [0])
-            schedule.timer.cancel()
+        if CIHelper.isRunningOnCI() {
+            let testExpectation = expectation(description: "Init With Handler")
+            var order: [Int] = []
+            
+            let schedule = Scheduler(deadline: .now(), repeating: .never) {
+                order.append(0)
+            }
+            
+            DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(3500)) {
+                testExpectation.fulfill()
+            }
+            
+            waitForExpectations(timeout: 5) { error in
+                XCTAssertNil(error)
+                XCTAssertEqual(order, [0])
+                schedule.timer.cancel()
+            }
         }
     }
 
     func testCancel() {
-        let testExpectation = expectation(description: "Init Without Handler")
-        var order: [Int] = []
+        if CIHelper.isRunningOnCI() {
+            let testExpectation = expectation(description: "Init Without Handler")
+            var order: [Int] = []
 
-        var schedule = Scheduler(deadline: .now(), repeating: .seconds(1))
-        schedule.setHandler {
-            order.append(0)
-            schedule.timer.cancel()
-        }
+            var schedule = Scheduler(deadline: .now(), repeating: .seconds(1))
+            schedule.setHandler {
+                order.append(0)
+                schedule.timer.cancel()
+            }
 
-        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(3500)) {
-            testExpectation.fulfill()
-        }
+            DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(3500)) {
+                testExpectation.fulfill()
+            }
 
-        waitForExpectations(timeout: 5) { error in
-            XCTAssertNil(error)
-            XCTAssertEqual(order, [0])
+            waitForExpectations(timeout: 5) { error in
+                XCTAssertNil(error)
+                XCTAssertEqual(order, [0])
+            }
         }
     }
-    #endif
 }

--- a/Tests/QueuerTests/SchedulerTests.swift
+++ b/Tests/QueuerTests/SchedulerTests.swift
@@ -30,7 +30,7 @@ import XCTest
 
 final class SchedulerTests: XCTestCase {
     func testInitWithoutHandler() {
-        if CIHelper.isRunningOnCI() {
+        if CIHelper.isNotRunningOnCI() {
             let testExpectation = expectation(description: "Init Without Handler")
             var order: [Int] = []
 
@@ -52,7 +52,7 @@ final class SchedulerTests: XCTestCase {
     }
 
     func testInitWithHandler() {
-        if CIHelper.isRunningOnCI() {
+        if CIHelper.isNotRunningOnCI() {
             let testExpectation = expectation(description: "Init With Handler")
             var order: [Int] = []
             
@@ -73,7 +73,7 @@ final class SchedulerTests: XCTestCase {
     }
 
     func testCancel() {
-        if CIHelper.isRunningOnCI() {
+        if CIHelper.isNotRunningOnCI() {
             let testExpectation = expectation(description: "Init Without Handler")
             var order: [Int] = []
 

--- a/Tests/QueuerTests/SemaphoreTests.swift
+++ b/Tests/QueuerTests/SemaphoreTests.swift
@@ -29,7 +29,7 @@ import XCTest
 
 final class SemaphoreTests: XCTestCase {
     func testWithSemaphore() {
-        if CIHelper.isRunningOnCI() {
+        if CIHelper.isNotRunningOnCI() {
             let semaphore = Semaphore()
             let queue = Queuer(name: "SemaphoreTestWithSemaphore")
             let testExpectation = expectation(description: "With Semaphore")
@@ -53,7 +53,7 @@ final class SemaphoreTests: XCTestCase {
     }
 
     func testWithoutSemaphore() {
-        if CIHelper.isRunningOnCI() {
+        if CIHelper.isNotRunningOnCI() {
             let queue = Queuer(name: "SemaphoreTestWithoutSemaphore")
             let testExpectation = expectation(description: "Without Semaphore")
             var testString = ""

--- a/Tests/QueuerTests/SemaphoreTests.swift
+++ b/Tests/QueuerTests/SemaphoreTests.swift
@@ -28,47 +28,49 @@ import Queuer
 import XCTest
 
 final class SemaphoreTests: XCTestCase {
-    #if !os(Linux)
     func testWithSemaphore() {
-        let semaphore = Semaphore()
-        let queue = Queuer(name: "SemaphoreTestWithSemaphore")
-        let testExpectation = expectation(description: "With Semaphore")
-        var testString = ""
+        if CIHelper.isRunningOnCI() {
+            let semaphore = Semaphore()
+            let queue = Queuer(name: "SemaphoreTestWithSemaphore")
+            let testExpectation = expectation(description: "With Semaphore")
+            var testString = ""
 
-        let concurrentOperation = ConcurrentOperation { _ in
-            Thread.sleep(forTimeInterval: 2)
-            testString = "Tested"
-            semaphore.continue()
-        }
-        concurrentOperation.addToQueue(queue)
+            let concurrentOperation = ConcurrentOperation { _ in
+                Thread.sleep(forTimeInterval: 2)
+                testString = "Tested"
+                semaphore.continue()
+            }
+            concurrentOperation.addToQueue(queue)
 
-        semaphore.wait()
-        XCTAssertEqual(testString, "Tested")
-        testExpectation.fulfill()
+            semaphore.wait()
+            XCTAssertEqual(testString, "Tested")
+            testExpectation.fulfill()
 
-        waitForExpectations(timeout: 5) { error in
-            XCTAssertNil(error)
+            waitForExpectations(timeout: 5) { error in
+                XCTAssertNil(error)
+            }
         }
     }
 
     func testWithoutSemaphore() {
-        let queue = Queuer(name: "SemaphoreTestWithoutSemaphore")
-        let testExpectation = expectation(description: "Without Semaphore")
-        var testString = ""
+        if CIHelper.isRunningOnCI() {
+            let queue = Queuer(name: "SemaphoreTestWithoutSemaphore")
+            let testExpectation = expectation(description: "Without Semaphore")
+            var testString = ""
 
-        let concurrentOperation = ConcurrentOperation { _ in
-            Thread.sleep(forTimeInterval: 2)
-            testString = "Tested"
-            testExpectation.fulfill()
-        }
-        concurrentOperation.addToQueue(queue)
+            let concurrentOperation = ConcurrentOperation { _ in
+                Thread.sleep(forTimeInterval: 2)
+                testString = "Tested"
+                testExpectation.fulfill()
+            }
+            concurrentOperation.addToQueue(queue)
 
-        XCTAssertEqual(testString, "")
+            XCTAssertEqual(testString, "")
 
-        waitForExpectations(timeout: 5) { error in
-            XCTAssertNil(error)
-            XCTAssertEqual(testString, "Tested")
+            waitForExpectations(timeout: 5) { error in
+                XCTAssertNil(error)
+                XCTAssertEqual(testString, "Tested")
+            }
         }
     }
-    #endif
 }


### PR DESCRIPTION
## Summary

Some tests randomly fail on GitHub Actions runners, but they don't on local Docker images.
This PR aims to check whether or not the tests are running on CI and skip them.

## Support

- [x] iOS
- [x] macOS
- [x] macCatalyst
- [x] tvOS
- [x] watchOS
- [x] visionOS
- [x] Linux

## Checklist

- [x] Added tests
- [x] Added documentation
- [x] Added a changelog entry
- [x] Added to the README the new functionality description
