### PR TITLE
Async Syntactic Sugar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - Added `addChainedAsyncOperations(_:completionHandler:)` and `addAsyncCompletionHandler(_:)` to `Queuer`, to chain operations with async completion handlers - [#38](https://github.com/FabrizioBrancati/Queuer/pull/38)
 - Added a Swift Testing test suite alongside the XCTest one, the XCTest suite runs on every supported toolchain, while the Swift Testing suite runs on Swift 6 and later - [#38](https://github.com/FabrizioBrancati/Queuer/pull/38)
 - Added `retryDelay` to `ConcurrentOperation` and `AsyncConcurrentOperation`, with its chainable `retryDelay(_:)` variant, to throttle automatic retries - [#38](https://github.com/FabrizioBrancati/Queuer/pull/38)
+- Added syntactic sugar for `AsyncConcurrentOperation`, with its fluent setters and the chainable `asyncConcurrent(_:)`, `asyncConcurrent(retries:_:)`, and `asyncCompletion(_:)` helpers on `Queuer` - [#38](https://github.com/FabrizioBrancati/Queuer/pull/39)
 - Added Dependabot for Swift packages and GitHub Actions dependencies, targeting the `develop` branch - [#38](https://github.com/FabrizioBrancati/Queuer/pull/38)
 - Added `pre-commit` hook [#43](https://github.com/FabrizioBrancati/Queuer/pull/43)
 - Added Makefile [#43](https://github.com/FabrizioBrancati/Queuer/pull/43)

--- a/README.md
+++ b/README.md
@@ -556,6 +556,38 @@ queue
     }
 ```
 
+`AsyncConcurrentOperation`s have the same chainable helpers (requires macOS 10.15, iOS 13, tvOS 13 or watchOS 6):
+
+```swift
+queue
+    .asyncConcurrent { _ in
+        /// Your asynchronous task here, it can throw
+        try await yourAsyncTask()
+    }
+    .asyncConcurrent(retries: 2) { operation in
+        /// Your retryable asynchronous task here
+        operation.success = false
+    }
+    .asyncCompletion {
+        /// Your asynchronous completion here
+        await yourAsyncCompletion()
+    }
+```
+
+And they can be configured with the same fluent style:
+
+```swift
+let operation = AsyncConcurrentOperation()
+    .name("MyAsyncOperation")
+    .queuePriority(.high)
+    .maximumRetries(5)
+    .retryDelay(1)
+    .executionBlock { operation in
+        /// Your asynchronous task here, it can throw
+        try await yourAsyncTask()
+    }
+```
+
 ## Changelog
 
 To see what has changed in recent versions of Queuer, see the **[CHANGELOG.md](https://github.com/FabrizioBrancati/Queuer/blob/main/CHANGELOG.md)** file.

--- a/Sources/Queuer/SyntacticSugar.swift
+++ b/Sources/Queuer/SyntacticSugar.swift
@@ -182,6 +182,45 @@ public extension Queuer {
         add(operation)
         return self
     }
+
+    /// Adds an `AsyncConcurrentOperation` with the given async throwing execution block.
+    ///
+    /// - Parameter block: Async throwing execution block.
+    /// - Returns: Returns the current `Queuer` instance.
+    @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+    @discardableResult
+    func asyncConcurrent(_ block: @escaping (_ operation: AsyncConcurrentOperation) async throws -> Void) -> Queuer {
+        addOperation(AsyncConcurrentOperation(executionBlock: block))
+        return self
+    }
+
+    /// Adds an `AsyncConcurrentOperation` with the given async throwing execution block
+    /// and maximum allowed retries.
+    ///
+    /// - Parameters:
+    ///   - retries: Maximum allowed retries.
+    ///   - block: Async throwing execution block.
+    /// - Returns: Returns the current `Queuer` instance.
+    @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+    @discardableResult
+    func asyncConcurrent(retries: Int, _ block: @escaping (_ operation: AsyncConcurrentOperation) async throws -> Void) -> Queuer {
+        let operation = AsyncConcurrentOperation(executionBlock: block)
+        operation.maximumRetries = retries
+        addOperation(operation)
+        return self
+    }
+
+    /// Adds an async completion block to the queue.
+    /// The completion waits for every `Operation` currently in the queue.
+    ///
+    /// - Parameter completion: Async completion block to be executed.
+    /// - Returns: Returns the current `Queuer` instance.
+    @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+    @discardableResult
+    func asyncCompletion(_ completion: @escaping @Sendable () async -> Void) -> Queuer {
+        addAsyncCompletionHandler(completion)
+        return self
+    }
 }
 
 /// `ConcurrentOperation` extension with syntactic sugar.
@@ -293,6 +332,121 @@ public extension ConcurrentOperation {
     /// - Returns: Returns the current `ConcurrentOperation` instance.
     @discardableResult
     func onCancel(_ block: @escaping (_ operation: ConcurrentOperation) -> Void) -> ConcurrentOperation {
+        self.onCancel = block
+        return self
+    }
+}
+
+/// `AsyncConcurrentOperation` extension with syntactic sugar.
+/// Every function returns the `AsyncConcurrentOperation` instance, so the calls can be chained.
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+public extension AsyncConcurrentOperation {
+    /// Sets the manual finish state.
+    ///
+    /// - Parameter manualFinish: Whether the `Operation` must be manually finished.
+    /// - Returns: Returns the current `AsyncConcurrentOperation` instance.
+    @discardableResult
+    func manualFinish(_ manualFinish: Bool = true) -> AsyncConcurrentOperation {
+        self.manualFinish = manualFinish
+        return self
+    }
+
+    /// Sets the manual retry state.
+    ///
+    /// - Parameter manualRetry: Whether the `Operation` must be manually retried.
+    /// - Returns: Returns the current `AsyncConcurrentOperation` instance.
+    @discardableResult
+    func manualRetry(_ manualRetry: Bool = true) -> AsyncConcurrentOperation {
+        self.manualRetry = manualRetry
+        return self
+    }
+
+    /// Sets the async throwing execution block.
+    ///
+    /// - Parameter block: Async throwing execution block.
+    /// - Returns: Returns the current `AsyncConcurrentOperation` instance.
+    @discardableResult
+    func executionBlock(_ block: @escaping (_ operation: AsyncConcurrentOperation) async throws -> Void) -> AsyncConcurrentOperation {
+        executionBlock = block
+        return self
+    }
+
+    /// Sets the maximum allowed retries.
+    ///
+    /// - Parameter retries: Maximum allowed retries.
+    /// - Returns: Returns the current `AsyncConcurrentOperation` instance.
+    @discardableResult
+    func maximumRetries(_ retries: Int) -> AsyncConcurrentOperation {
+        maximumRetries = retries
+        return self
+    }
+
+    /// Sets the throttling between each automatic retry.
+    ///
+    /// - Parameter delay: Delay between each automatic retry.
+    /// - Returns: Returns the current `AsyncConcurrentOperation` instance.
+    @discardableResult
+    func retryDelay(_ delay: TimeInterval) -> AsyncConcurrentOperation {
+        retryDelay = delay
+        return self
+    }
+
+    /// Sets the `Operation` name.
+    ///
+    /// - Parameter name: `Operation` name.
+    /// - Returns: Returns the current `AsyncConcurrentOperation` instance.
+    @discardableResult
+    func name(_ name: String) -> AsyncConcurrentOperation {
+        self.name = name
+        return self
+    }
+
+    /// Sets the execution priority in its queue.
+    ///
+    /// - Parameter priority: Execution priority.
+    /// - Returns: Returns the current `AsyncConcurrentOperation` instance.
+    @discardableResult
+    func queuePriority(_ priority: Operation.QueuePriority) -> AsyncConcurrentOperation {
+        self.queuePriority = priority
+        return self
+    }
+
+    /// Sets the service level to apply to the `Operation`.
+    ///
+    /// - Parameter quality: The service level.
+    /// - Returns: Returns the current `AsyncConcurrentOperation` instance.
+    @discardableResult
+    func qualityOfService(_ quality: QualityOfService) -> AsyncConcurrentOperation {
+        self.qualityOfService = quality
+        return self
+    }
+
+    /// Sets the block to be called when the `Operation` is paused.
+    ///
+    /// - Parameter block: Pause block.
+    /// - Returns: Returns the current `AsyncConcurrentOperation` instance.
+    @discardableResult
+    func onPause(_ block: @escaping (_ operation: AsyncConcurrentOperation) -> Void) -> AsyncConcurrentOperation {
+        self.onPause = block
+        return self
+    }
+
+    /// Sets the block to be called when the `Operation` is resumed.
+    ///
+    /// - Parameter block: Resume block.
+    /// - Returns: Returns the current `AsyncConcurrentOperation` instance.
+    @discardableResult
+    func onResume(_ block: @escaping (_ operation: AsyncConcurrentOperation) -> Void) -> AsyncConcurrentOperation {
+        self.onResume = block
+        return self
+    }
+
+    /// Sets the block to be called when the `Operation` is canceled.
+    ///
+    /// - Parameter block: Cancel block.
+    /// - Returns: Returns the current `AsyncConcurrentOperation` instance.
+    @discardableResult
+    func onCancel(_ block: @escaping (_ operation: AsyncConcurrentOperation) -> Void) -> AsyncConcurrentOperation {
         self.onCancel = block
         return self
     }

--- a/Tests/QueuerTests/ConcurrentOperationTests.swift
+++ b/Tests/QueuerTests/ConcurrentOperationTests.swift
@@ -134,7 +134,9 @@ struct ConcurrentOperationTests {
             completed.mutate { $0 = true }
         }
 
-        #expect(await waitUntil { completed.value })
+        /// Every attempt hops through an unstructured `Task`:
+        /// give slow emulators with few cores some extra headroom.
+        #expect(await waitUntil(timeout: 20) { completed.value })
         #expect(order.value == [0, 0, 0, 1, 1, 1, 2])
     }
 
@@ -192,9 +194,9 @@ struct ConcurrentOperationTests {
         /// Trigger a retry as soon as the previous attempt has been executed,
         /// instead of relying on wall clock delays.
         onBackgroundThread {
-            waitUntil(timeout: 8) { order.count >= 1 && concurrentOperation1.currentAttempt == 2 }
+            guard waitUntil(timeout: 8, { order.count >= 1 && concurrentOperation1.currentAttempt == 2 }) else { return }
             concurrentOperation1.retry()
-            waitUntil(timeout: 8) { order.count >= 2 && concurrentOperation1.currentAttempt == 3 }
+            guard waitUntil(timeout: 8, { order.count >= 2 && concurrentOperation1.currentAttempt == 3 }) else { return }
             concurrentOperation1.retry()
         }
 
@@ -357,11 +359,11 @@ struct ConcurrentOperationTests {
         concurrentOperation.addToQueue(queue)
 
         onBackgroundThread {
-            waitUntil(timeout: 8) { order.count >= 1 }
+            guard waitUntil(timeout: 8, { order.count >= 1 }) else { return }
             concurrentOperation.retry()
-            waitUntil(timeout: 8) { order.count >= 2 }
+            guard waitUntil(timeout: 8, { order.count >= 2 }) else { return }
             concurrentOperation.retry()
-            waitUntil(timeout: 8) { order.count >= 3 }
+            guard waitUntil(timeout: 8, { order.count >= 3 }) else { return }
             /// The operation must not be finished until `finish(success:)` is called.
             finishedBeforeManualFinish.mutate { $0 = concurrentOperation.isFinished }
             concurrentOperation.finish()

--- a/Tests/QueuerTests/GroupOperationTests.swift
+++ b/Tests/QueuerTests/GroupOperationTests.swift
@@ -209,17 +209,19 @@ struct GroupOperationTests {
         /// Trigger every retry as soon as the previous attempt has been recorded,
         /// instead of relying on wall clock delays.
         onBackgroundThread {
-            waitUntil(timeout: 8) { order.count >= 2 && concurrentOperation1.currentAttempt == 2 }
+            guard waitUntil(timeout: 8, { order.count >= 2 && concurrentOperation1.currentAttempt == 2 }) else { return }
             concurrentOperation1.retry()
-            waitUntil(timeout: 8) { order.count >= 3 && concurrentOperation2.currentAttempt == 2 }
+            guard waitUntil(timeout: 8, { order.count >= 3 && concurrentOperation2.currentAttempt == 2 }) else { return }
             concurrentOperation2.retry()
-            waitUntil(timeout: 8) { order.count >= 4 && concurrentOperation2.currentAttempt == 3 }
+            guard waitUntil(timeout: 8, { order.count >= 4 && concurrentOperation2.currentAttempt == 3 }) else { return }
             concurrentOperation2.retry()
-            waitUntil(timeout: 8) { order.count >= 5 && concurrentOperation1.currentAttempt == 3 }
+            guard waitUntil(timeout: 8, { order.count >= 5 && concurrentOperation1.currentAttempt == 3 }) else { return }
             concurrentOperation1.retry()
         }
 
-        #expect(await waitUntil { completed.value })
+        /// The retries are driven step by step from a background thread:
+        /// give slow emulators with few cores some extra headroom.
+        #expect(await waitUntil(timeout: 20) { completed.value })
         #expect(order.value == ["1", "2", "1", "2", "2", "1", "3"])
     }
 

--- a/Tests/QueuerTests/Helpers/TestHelper.swift
+++ b/Tests/QueuerTests/Helpers/TestHelper.swift
@@ -70,10 +70,12 @@ extension Protected where Value: RangeReplaceableCollection {
 /// - Returns: Returns `true` if the condition became true before the timeout, otherwise `false`.
 @discardableResult
 func waitUntil(timeout: TimeInterval = 10, _ condition: () -> Bool) -> Bool {
-    let deadline = Date().addingTimeInterval(timeout)
+    /// The deadline uses a monotonic clock: the wall clock can jump,
+    /// for example when an emulator syncs its time, and would burn the budget.
+    let deadline = DispatchTime.now() + timeout
 
     while !condition() {
-        guard Date() < deadline else {
+        guard DispatchTime.now() < deadline else {
             return false
         }
 
@@ -93,10 +95,12 @@ func waitUntil(timeout: TimeInterval = 10, _ condition: () -> Bool) -> Bool {
 @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 @discardableResult
 func waitUntil(timeout: TimeInterval = 10, _ condition: @Sendable () -> Bool) async -> Bool {
-    let deadline = Date().addingTimeInterval(timeout)
+    /// The deadline uses a monotonic clock: the wall clock can jump,
+    /// for example when an emulator syncs its time, and would burn the budget.
+    let deadline = DispatchTime.now() + timeout
 
     while !condition() {
-        guard Date() < deadline else {
+        guard DispatchTime.now() < deadline else {
             return false
         }
 

--- a/Tests/QueuerTests/SchedulerTests.swift
+++ b/Tests/QueuerTests/SchedulerTests.swift
@@ -126,7 +126,7 @@ struct SchedulerTests {
         }
 
         onBackgroundThread {
-            waitUntil(timeout: 8) { order.value.contains(0) }
+            guard waitUntil(timeout: 8, { order.value.contains(0) }) else { return }
 
             /// Setting the handler again must replace the previous one, without crashing.
             schedule.mutate {

--- a/Tests/QueuerTests/SyntacticSugarTests.swift
+++ b/Tests/QueuerTests/SyntacticSugarTests.swift
@@ -206,6 +206,60 @@ struct SyntacticSugarTests {
     }
 
     @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+    @Test("Fluent setters configure the async operation")
+    func asyncConcurrentOperationSugar() {
+        let concurrentOperation = AsyncConcurrentOperation()
+            .name("AsyncSugarOperation")
+            .queuePriority(.high)
+            .qualityOfService(.utility)
+            .manualFinish()
+            .manualRetry()
+            .maximumRetries(5)
+            .retryDelay(1)
+            .executionBlock { _ in }
+            .onPause { _ in }
+            .onResume { _ in }
+            .onCancel { _ in }
+
+        #expect(concurrentOperation.name == "AsyncSugarOperation")
+        #expect(concurrentOperation.queuePriority == .high)
+        #expect(concurrentOperation.qualityOfService == .utility)
+        #expect(concurrentOperation.manualFinish)
+        #expect(concurrentOperation.manualRetry)
+        #expect(concurrentOperation.maximumRetries == 5)
+        #expect(concurrentOperation.retryDelay == 1)
+        #expect(concurrentOperation.executionBlock != nil)
+        #expect(concurrentOperation.onPause != nil)
+        #expect(concurrentOperation.onResume != nil)
+        #expect(concurrentOperation.onCancel != nil)
+    }
+
+    @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+    @Test("Async concurrent blocks and async completion run in order")
+    func asyncConcurrentAndAsyncCompletion() async {
+        let order = Protected<[String]>([])
+        let completed = Protected(false)
+
+        Queuer(name: "SyntacticSugarTestAsyncConcurrent")
+            .maxConcurrentOperationCount(1)
+            .asyncConcurrent { _ in
+                order.append("First")
+            }
+            .asyncConcurrent(retries: 2) { operation in
+                order.append("Retry")
+                operation.success = false
+            }
+            .asyncCompletion {
+                order.append("Finished")
+                completed.mutate { $0 = true }
+            }
+
+        #expect(await waitUntil { completed.value })
+        /// "Retry" fails with 2 maximum retries.
+        #expect(order.value == ["First", "Retry", "Retry", "Finished"])
+    }
+
+    @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     @Test("Chained blocks and retryable concurrent blocks run in order")
     func chainedBlocksAndConcurrentRetries() async {
         let order = Protected<[String]>([])

--- a/Tests/QueuerXCTests/ConcurrentOperationTests.swift
+++ b/Tests/QueuerXCTests/ConcurrentOperationTests.swift
@@ -208,9 +208,9 @@ final class ConcurrentOperationTests: XCTestCase {
         /// Trigger a retry as soon as the previous attempt has been executed,
         /// instead of relying on wall clock delays.
         onBackgroundThread {
-            waitUntil(timeout: 8) { order.count >= 1 && concurrentOperation1.currentAttempt == 2 }
+            guard waitUntil(timeout: 8, { order.count >= 1 && concurrentOperation1.currentAttempt == 2 }) else { return }
             concurrentOperation1.retry()
-            waitUntil(timeout: 8) { order.count >= 2 && concurrentOperation1.currentAttempt == 3 }
+            guard waitUntil(timeout: 8, { order.count >= 2 && concurrentOperation1.currentAttempt == 3 }) else { return }
             concurrentOperation1.retry()
         }
 
@@ -412,11 +412,11 @@ final class ConcurrentOperationTests: XCTestCase {
         concurrentOperation.addToQueue(queue)
 
         onBackgroundThread {
-            waitUntil(timeout: 8) { order.count >= 1 }
+            guard waitUntil(timeout: 8, { order.count >= 1 }) else { return }
             concurrentOperation.retry()
-            waitUntil(timeout: 8) { order.count >= 2 }
+            guard waitUntil(timeout: 8, { order.count >= 2 }) else { return }
             concurrentOperation.retry()
-            waitUntil(timeout: 8) { order.count >= 3 }
+            guard waitUntil(timeout: 8, { order.count >= 3 }) else { return }
             XCTAssertFalse(concurrentOperation.isFinished)
             concurrentOperation.finish()
             testExpectation.fulfill()

--- a/Tests/QueuerXCTests/GroupOperationTests.swift
+++ b/Tests/QueuerXCTests/GroupOperationTests.swift
@@ -206,13 +206,13 @@ final class GroupOperationTests: XCTestCase {
         /// Trigger every retry as soon as the previous attempt has been recorded,
         /// instead of relying on wall clock delays.
         onBackgroundThread {
-            waitUntil(timeout: 8) { order.count >= 2 && concurrentOperation1.currentAttempt == 2 }
+            guard waitUntil(timeout: 8, { order.count >= 2 && concurrentOperation1.currentAttempt == 2 }) else { return }
             concurrentOperation1.retry()
-            waitUntil(timeout: 8) { order.count >= 3 && concurrentOperation2.currentAttempt == 2 }
+            guard waitUntil(timeout: 8, { order.count >= 3 && concurrentOperation2.currentAttempt == 2 }) else { return }
             concurrentOperation2.retry()
-            waitUntil(timeout: 8) { order.count >= 4 && concurrentOperation2.currentAttempt == 3 }
+            guard waitUntil(timeout: 8, { order.count >= 4 && concurrentOperation2.currentAttempt == 3 }) else { return }
             concurrentOperation2.retry()
-            waitUntil(timeout: 8) { order.count >= 5 && concurrentOperation1.currentAttempt == 3 }
+            guard waitUntil(timeout: 8, { order.count >= 5 && concurrentOperation1.currentAttempt == 3 }) else { return }
             concurrentOperation1.retry()
         }
 

--- a/Tests/QueuerXCTests/Helpers/TestHelper.swift
+++ b/Tests/QueuerXCTests/Helpers/TestHelper.swift
@@ -70,10 +70,12 @@ extension Protected where Value: RangeReplaceableCollection {
 /// - Returns: Returns `true` if the condition became true before the timeout, otherwise `false`.
 @discardableResult
 func waitUntil(timeout: TimeInterval = 10, _ condition: () -> Bool) -> Bool {
-    let deadline = Date().addingTimeInterval(timeout)
+    /// The deadline uses a monotonic clock: the wall clock can jump,
+    /// for example when an emulator syncs its time, and would burn the budget.
+    let deadline = DispatchTime.now() + timeout
 
     while !condition() {
-        guard Date() < deadline else {
+        guard DispatchTime.now() < deadline else {
             return false
         }
 

--- a/Tests/QueuerXCTests/SchedulerTests.swift
+++ b/Tests/QueuerXCTests/SchedulerTests.swift
@@ -129,7 +129,7 @@ final class SchedulerTests: XCTestCase {
         }
 
         onBackgroundThread {
-            waitUntil(timeout: 8) { order.value.contains(0) }
+            guard waitUntil(timeout: 8, { order.value.contains(0) }) else { return }
 
             /// Setting the handler again must replace the previous one, without crashing.
             schedule.mutate {

--- a/Tests/QueuerXCTests/SyntacticSugarTests.swift
+++ b/Tests/QueuerXCTests/SyntacticSugarTests.swift
@@ -235,4 +235,58 @@ final class SyntacticSugarTests: XCTestCase {
             XCTAssertGreaterThanOrEqual(Date().timeIntervalSince(start), 0.05)
         }
     }
+
+    @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+    func testAsyncConcurrentOperationSugar() {
+        let concurrentOperation = AsyncConcurrentOperation()
+            .name("AsyncSugarOperation")
+            .queuePriority(.high)
+            .qualityOfService(.utility)
+            .manualFinish()
+            .manualRetry()
+            .maximumRetries(5)
+            .retryDelay(1)
+            .executionBlock { _ in }
+            .onPause { _ in }
+            .onResume { _ in }
+            .onCancel { _ in }
+
+        XCTAssertEqual(concurrentOperation.name, "AsyncSugarOperation")
+        XCTAssertEqual(concurrentOperation.queuePriority, .high)
+        XCTAssertEqual(concurrentOperation.qualityOfService, .utility)
+        XCTAssertTrue(concurrentOperation.manualFinish)
+        XCTAssertTrue(concurrentOperation.manualRetry)
+        XCTAssertEqual(concurrentOperation.maximumRetries, 5)
+        XCTAssertEqual(concurrentOperation.retryDelay, 1)
+        XCTAssertNotNil(concurrentOperation.executionBlock)
+        XCTAssertNotNil(concurrentOperation.onPause)
+        XCTAssertNotNil(concurrentOperation.onResume)
+        XCTAssertNotNil(concurrentOperation.onCancel)
+    }
+
+    @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+    func testAsyncConcurrentAndAsyncCompletion() {
+        let testExpectation = expectation(description: "Async Concurrent And Async Completion")
+        let order = Protected<[String]>([])
+
+        Queuer(name: "SyntacticSugarTestAsyncConcurrent")
+            .maxConcurrentOperationCount(1)
+            .asyncConcurrent { _ in
+                order.append("First")
+            }
+            .asyncConcurrent(retries: 2) { operation in
+                order.append("Retry")
+                operation.success = false
+            }
+            .asyncCompletion {
+                order.append("Finished")
+                testExpectation.fulfill()
+            }
+
+        waitForExpectations(timeout: 10) { error in
+            XCTAssertNil(error)
+            /// "Retry" fails with 2 maximum retries.
+            XCTAssertEqual(order.value, ["First", "Retry", "Retry", "Finished"])
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Adding syntactic sugar for AsyncConcurrentOperation.

## Support

- [x] iOS
- [x] macOS
- [x] macCatalyst
- [x] tvOS
- [x] watchOS
- [x] visionOS
- [x] Linux
- [x] Android
- [x] Windows

## Checklist

_Make sure you check off the following items. If they cannot be completed, provide a reason._

- [x] Added tests
- [x] Added documentation
- [x] Added a changelog entry
- [x] Added to the README the new functionality description
